### PR TITLE
Add OpenCnC.Net.Math project file

### DIFF
--- a/Src/OpenCnC.Net.Math/OpenCnC.Net.Math.csproj
+++ b/Src/OpenCnC.Net.Math/OpenCnC.Net.Math.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>OpenCnC.Net.Math</RootNamespace>
+        <DefineTrace>true</DefineTrace>
+    </PropertyGroup>
+
+    <Choose>
+        <When Condition="'$(Configuration)' == 'Debug'">
+            <PropertyGroup>
+                <DefineDebug>true</DefineDebug>
+                <DebugSymbols>true</DebugSymbols>
+                <DebugType>full</DebugType>
+                <Optimize>false</Optimize>
+            </PropertyGroup>
+        </When>
+        <When Condition="'$(Configuration)' == 'Release'">
+            <PropertyGroup>
+                <DefineDebug>false</DefineDebug>
+                <DebugSymbols>false</DebugSymbols>
+                <DebugType>portable</DebugType>
+                <Optimize>none</Optimize>
+            </PropertyGroup>
+        </When>
+    </Choose>
+
+</Project>


### PR DESCRIPTION
This commit introduces a new .NET 8.0 project file for OpenCnC.Net.Math.

It includes default configurations for Debug and Release modes, enabling nullable reference types and implicit using directives.

This sets the foundation for future mathematical functionalities.