### PR TITLE
Add Constants class with Pi constant

### DIFF
--- a/Src/OpenCnC.Net.Math/Constants.cs
+++ b/Src/OpenCnC.Net.Math/Constants.cs
@@ -1,0 +1,6 @@
+namespace OpenCnC.Net.Math;
+
+public static class Constants
+{
+    public static float Pi => 3.14159265359F;
+}


### PR DESCRIPTION
Introduces a new `Constants` class in the `OpenCnC.Net.Math` namespace.

This class provides a static property for the mathematical constant Pi.