### PR TITLE
Relocate angle classes to a dedicated namespace.

### DIFF
--- a/Src/OpenCnC.Net.Math/Angles/Degrees.cs
+++ b/Src/OpenCnC.Net.Math/Angles/Degrees.cs
@@ -1,4 +1,4 @@
-namespace OpenCnC.Net.Math;
+namespace OpenCnC.Net.Math.Angles;
 
 public class Degrees(float value)
 {

--- a/Src/OpenCnC.Net.Math/Angles/Radians.cs
+++ b/Src/OpenCnC.Net.Math/Angles/Radians.cs
@@ -1,4 +1,4 @@
-namespace OpenCnC.Net.Math;
+namespace OpenCnC.Net.Math.Angles;
 
 public class Radians(float value)
 {


### PR DESCRIPTION
Moved `Degrees` and `Radians` classes into the `OpenCnC.Net.Math.Angles` namespace for better organization and separation of concerns.

This change improves code structure and makes the purpose of these classes more explicit.